### PR TITLE
Template for script.R now also loads dplyr for the filter_() function.

### DIFF
--- a/inst/templates/default.R
+++ b/inst/templates/default.R
@@ -3,6 +3,7 @@
 suppressMessages({
   library(trac2gh)
   library(gsubfn)
+  library(dplyr)
 })
 
 con <- file("stdin", blocking=TRUE)


### PR DESCRIPTION
Otherwise, you get mid-run errors like

```
Error in (function (ticket_id, db = d)  : 
  could not find function "filter_"
Calls: gsubfn ... paste -> sapply -> lapply -> FUN -> do.call -> <Anonymous>
Execution halted
```